### PR TITLE
remove button and style Link componente

### DIFF
--- a/src/diputados/components/DipCard.tsx
+++ b/src/diputados/components/DipCard.tsx
@@ -1,5 +1,4 @@
 import { Link } from "react-router-dom";
-import { Button } from "flowbite-react";
 
 interface DipMode {
   id: number;
@@ -21,9 +20,10 @@ export const DipCard = ({ id, Nombre, Apellido, bloque, email }: DipMode) => {
         <p className="text-justify text-gray-600">{bloque}</p>
         <p className="text-justify text-gray-600">{email}</p>
       </div>
-      <Button className="m-4" gradientMonochrome="info">
-        <Link to={`/dipPage/${id}`}>Más...</Link>
-      </Button>
+
+      <Link className="px-5 py-2 m-4 font-medium text-center text-white rounded-lg bg-gradient-to-r from-teal-400 via-teal-500 to-teal-600 hover:bg-gradient-to-br focus:ring-4 focus:outline-none focus:ring-teal-300 dark:focus:ring-teal-800" to={`/dipPage/${id}`}>
+        Más...
+      </Link>
     </div>
   );
 };

--- a/src/uiDesing/components/NavBar.tsx
+++ b/src/uiDesing/components/NavBar.tsx
@@ -15,19 +15,19 @@ export const NavBar = () => {
       <Navbar.Toggle />
       <Navbar.Collapse>
         <Link
-          className="p-1 rounded-sm hover:bg-slate-400 active:bg-slate-200 focus:ring focus:bg-slate-200"
+          className="px-2 py-1 transition-colors rounded-sm hover:text-white hover:bg-slate-400 active:bg-slate-200 focus:ring focus:bg-slate-200"
           to="/"
         >
           Home
         </Link>
         <Link
-          className="p-1 rounded-sm hover:bg-slate-400 active:bg-slate-200 focus:ring focus:bg-slate-200"
+          className="px-2 py-1 transition-colors rounded-sm hover:text-white hover:bg-slate-400 active:bg-slate-200 focus:ring focus:bg-slate-200"
           to="/about"
         >
           About
         </Link>
         <Link
-          className="p-1 rounded-sm hover:bg-slate-400 active:bg-slate-200 focus:ring focus:bg-slate-200"
+          className="px-2 py-1 transition-colors rounded-sm hover:text-white hover:bg-slate-400 active:bg-slate-200 focus:ring focus:bg-slate-200"
           to="/contact"
         >
           Contact


### PR DESCRIPTION
No usar un Link dentro de un button. Si le doy un bg al link se ve que no ocupa todo el contenido boton, por lo tanto a hacer click en alguna parte que NO contiene el texto no va a cambiar de página. 
Mejor solo usar el componente Link y darle el estilo del botón.
![Screenshot 2024-05-13 170714](https://github.com/Danielcabrera1988/biblioteca-leg/assets/97553097/1ba29bd6-6905-4d68-80d9-736e6e0308d2)
